### PR TITLE
fix(ci): Ignore fails during tags fetching

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Add upstream remote
         run: |
           git remote add upstream https://github.com/zalando/spilo.git
-          git fetch upstream --tags
+          git fetch upstream --tags || true
 
       - name: Rebase fork default branch onto upstream
         run: |


### PR DESCRIPTION
It is caused because existing tags make `git fetch` exit 1